### PR TITLE
Remove py34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-- '3.4'
 - '3.5'
 - '3.6'
 - nightly
@@ -28,7 +27,7 @@ deploy:
   on:
     branch: master
     tags: true
-    condition: $TRAVIS_PYTHON_VERSION = "3.4"
+    condition: $TRAVIS_PYTHON_VERSION = "3.5"
 notifications:
   slack:
     secure: LiRVoggt16ZNgzVw7zuTejrTPF8s2LZUw6gKeqIlw8b6q/kyY+i94PVgFDT0qSugfUjq4L5/r48rJ7Vpd2coHDimmMx6OTyhTv2P0iCLTP9x5OdltEBsIV/4lsyKl5IHVaM4gjUIpfsDRJohGjccAa4XAIzWguojn2Ea2dVXjw3oYpGSMye4GKQfkbkUwz0PqumppniLE1LkwK9ing5kin5DQtqBIBu3bcuv1a956e3KODPvMfkaOlhHOXZjITBuqo8H2gcajmnH/U7d6fioVQKUKGS4/RwrEmZgiFhSsRiZJXJ/jal9RPpVAfIN81/Ke3PsWBZs/JBxQx2hcUpJKhO1Uyz/Nt0Ph6SiufO97H6MindN5+90PxU+a6eTfMY8vrtSPmfreo39TyjQWB58AZ5SoJ5jAq5ldbF/E6E+tLtRWNKdeY8iPzLSwACaxj5clxRPOGOgmmgmkJUomUXVKQe2EIa+MZtTcQGg6bU391vdfMGmSeMQxW76gsifGF5m1kKM+rw9arddN7MnbvXwPdQ7so/ZYiWnlGgh/mestiKpAPf7WUHhrBMQ5L9sSLbEwETPbZehs1kYk4GS2tZ566b8pR6kejEvS0HpSIawtxdTfRy7DWcatRbuiTkynW028HDqEuNJrf1RDP1onaYBArGji1sP8DT+QQV2nLssddI=

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 [![Documentation Status](https://readthedocs.org/projects/wire-protocol/badge/?version=latest)](http://wire-protocol.readthedocs.io/en/latest/?badge=latest)
 
-[![Stories in Ready](https://badge.waffle.io/adbpy/wire-protocol.svg?label=ready&title=Ready)](http://waffle.io/adbpy/wire-protocol)
-
 Android Debug Bridge (ADB) Wire Protocol
 
 ## Status

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,5 +2,4 @@
 #
 # Requirements for using this package.
 
-enum34==1.1.6; python_version < '3.4'
 typing==3.6.6; python_version < '3.6'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
If merged, this removes support for python 3.4. Future PR's will pull in support for newer python versions.